### PR TITLE
Inroom related things

### DIFF
--- a/Assets/Scripts/UIEvents/RoomItem.cs
+++ b/Assets/Scripts/UIEvents/RoomItem.cs
@@ -41,6 +41,8 @@ public class RoomItem : MonoBehaviour
 
         ChangeReady(IsReady);
 
+        nameInputField.interactable = !IsReady;
+
     }
 
     public void ChangeReady(bool isReady)

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -140,8 +140,7 @@ PlayerSettings:
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
   bundleVersion: 0.1.0
-  preloadedAssets:
-  - {fileID: 11400000, guid: 9e7be553448fa2546aea5752021cbcf7, type: 2}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
In issue #26 
3. There will be flickering and stuttering when players enter their names on the room page
4. When refreshing the room, it may get stuck

Fixed by adding network check and not allowed user change their name after click ready btn